### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install .
 **Note**: *This will install the cpu version of pytorch by default. For CUDA acceleration, you will need to manually
 find and install compatible pytorch and pytorch geometric versions.*
 
-**4.** Download a pretrained model's weights through [here](https://www.dropbox.com/scl/fi/58i2mhpfkctp9lasw3fc6/model.pt?rlkey=8dhc69p9798r9drskcx06j449&st=talhqkgl&dl=0).
+**4.** Download a pretrained model's weights through [here](https://www.dropbox.com/scl/fi/zd2s1evanh7jrrtdofr4d/model.pt?rlkey=yxjj07jvlnfikz1t40e32kguk&st=ccu15xkn&dl=0).
 
 **Note**: *Optional. Only relevant for inference/evaluation.*
 
@@ -46,10 +46,13 @@ You can **uninstall** by removing the environment from your system, and deleting
 ### 🪿 Interface with Agda
 
 > 🚧 **Note**: Work in Progress 🚧
-
+>
+> Bear in mind that the main branches of agda2train and quill are not necessarily in sync.
+ 
 You should be able to export an Agda file (possibly containing holes) into json format 
 (see [agda2train](https://github.com/omelkonian/agda2train)), and then invoke a script that looks like `/scripts/inference.py`
 to obtain lemma suggestions.
+ 
 
 The second part of this process is partially streamlined through a CLI API.
 
@@ -76,6 +79,11 @@ agda-quill query -file ./data/stdlib/Algebra.Construct.NaturalChoice.Min.json --
 Adjust the training configuration file (`/data/config.json`) and run the training script (`/scripts/train.py`), after any necessary modifications.
 
 #### ... on a new dataset
+
+> ⚠️ **Warning**: Unpinned Dependencies ⚠️
+>
+> The current packaging of quill is tied to the bundled `tokenized.p`. Differences in agda2train versions might necessitate different preprocessing or data digestion pipelines. 
+
 Gather a bunch of JSON exports over an Agda library of your choice (again, using [agda2train](https://github.com/omelkonian/agda2train)).
 Run the preprocessing script (`/scripts/preprocess.py`) to have Python parse and tokenize the exports.
 Then train as you would normally.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import json
 import argparse
 import pickle
@@ -16,6 +17,7 @@ def train(
         data_path: str,
         store_path: str,
         log_path: str,
+        checkpoint_path: str,
         device: str):
     logger = Logger(sys.stdout, log_path)
     sys.stdout = logger
@@ -30,8 +32,6 @@ def train(
     dev_files = [file for file in files if file.file.name in config['dev_files']]
     train_files, _ = split_by_length(train_files, config['max_tokens'])
     dev_files, _ = split_by_length(dev_files, config['max_tokens'])
-    print(f'Training on {len(train_files)} files with {sum(len(file.hole_asts) for file in train_files)} holes.')
-    print(f'Evaluating on {len(dev_files)} files with {sum(len(file.hole_asts) for file in dev_files)} holes.')
 
     train_sampler = Sampler(train_files)
     epoch_size = train_sampler.itersize(config['batch_size_s'] * config['backprop_every'], config['batch_size_h'])
@@ -48,8 +48,11 @@ def train(
     )
     scheduler = LambdaLR(optimizer=optimizer, lr_lambda=schedule, last_epoch=-1)
 
-    best_ap = -1e08
-    for epoch in range(config['num_epochs']):
+    start_epoch, best_ap = 0, -1e08
+    if os.path.exists(checkpoint_path):
+        start_epoch, best_ap = model.load_checkpoint(checkpoint_path, optimizer, scheduler, device)
+        print(f'Resuming from checkpoint at epoch {start_epoch}.')
+    for epoch in range(start_epoch, config['num_epochs']):
         print(f'Epoch {epoch}')
         print('-' * 64)
         train_epoch = model.train_epoch(
@@ -70,6 +73,7 @@ def train(
             print('Saving...')
             model.save(store_path)
             best_ap = sum(dev_epoch.ap)
+        model.save_checkpoint(checkpoint_path, optimizer, scheduler, epoch, best_ap)
         print('=' * 64 + '\n')
     logger.flush()
 
@@ -84,6 +88,8 @@ def parse_args():
                         default='../data/model.pt')
     parser.add_argument('--log_path', type=str, help='Where to log results',
                         default='../data/log.txt')
+    parser.add_argument('--checkpoint_path', type=str, help='Where to store/resume the training checkpoint',
+                        default='../data/checkpoint.pt')
     return parser.parse_args()
 
 
@@ -95,5 +101,6 @@ if __name__ == '__main__':
         data_path=args.data_path,
         store_path=args.store_path,
         log_path=args.log_path,
+        checkpoint_path=args.checkpoint_path,
         device='cuda',
     )

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,3 +1,4 @@
+import sys
 import json
 import argparse
 import pickle
@@ -38,11 +39,13 @@ def train(
 
     model = Trainer(config['model_config']).to(device)
     optimizer = AdamW(params=model.parameters(), lr=1, weight_decay=1e-02)
-    schedule = make_schedule(warmup_steps=config['warmup_epochs'] * epoch_size,
-                             warmdown_steps=config['warmdown_epochs'] * epoch_size,
-                             max_lr=config['max_lr'],
-                             min_lr=config['min_lr'],
-                             total_steps=config['num_epochs'] * epoch_size)
+    schedule = make_schedule(
+        warmup_steps=config['warmup_epochs'] * epoch_size,
+        warmdown_steps=config['warmdown_epochs'] * epoch_size,
+        max_lr=config['max_lr'],
+        min_lr=config['min_lr'],
+        total_steps=config['num_epochs'] * epoch_size
+    )
     scheduler = LambdaLR(optimizer=optimizer, lr_lambda=schedule, last_epoch=-1)
 
     best_ap = -1e08

--- a/src/quill/data/tokenization.py
+++ b/src/quill/data/tokenization.py
@@ -51,7 +51,7 @@ def tokenize_file(original: File[str], merge_holes: bool = True, unique_only: bo
     zipped_scopes = tuple(zip(*[
         (i, tokenize_ast(term_to_ast(entry.type, 1, ()))) for i, entry in enumerate(anonymous.scope)]))
     zipped_holes = tuple(zip(*[
-        (i, tokenize_ast(term_to_ast(hole.goal, 1, ())), [n for lemma in hole.premises if (n := lemma.name) != 1])
+        (i, tokenize_ast(term_to_ast(hole.goal, 1, ())), [n for lemma in hole.premises if (n := lemma.name) != -1])
         for i, entry in enumerate(anonymous.scope) for hole in entry.holes]))
     scope_positions, scope_asts = zipped_scopes or ([], [])
     hole_to_scope, hole_asts, premises = zipped_holes or ([], [], [])

--- a/src/quill/nn/batching.py
+++ b/src/quill/nn/batching.py
@@ -143,9 +143,22 @@ class Collator:
 
 
 def discard_empty(files: list[TokenizedFile]) -> list[TokenizedFile]:
-    return [file for file in files if len(file.hole_asts) and
-            all(len(hole) > 0 and any(p != -1 for p in hole) for hole in file.premises)]
+    def is_solvable(premises: list[int]) -> bool:
+        return any(premise != -1 for premise in premises)
 
+    def keep_valid_holes(file: TokenizedFile) -> TokenizedFile | None:
+        valid = [i for i, premises in enumerate(file.premises) if is_solvable(premises)]
+        if not valid:
+            return None
+        return TokenizedFile(
+            file=file.file,
+            backrefs=file.backrefs,
+            entry_sort=file.entry_sort,
+            scope_asts=file.scope_asts,
+            hole_to_scope=[file.hole_to_scope[i] for i in valid],
+            hole_asts=[file.hole_asts[i] for i in valid],
+            premises=[file.premises[i] for i in valid])
+    return list(filter(None, map(keep_valid_holes, files)))
 
 def split_by_length(files: list[TokenizedFile], max_tokens: int) -> tuple[list[TokenizedFile], list[TokenizedFile]]:
     flags = [sum(len(ast) for ast in file.scope_asts) <= max_tokens for file in files]

--- a/src/quill/nn/embedding.py
+++ b/src/quill/nn/embedding.py
@@ -4,6 +4,7 @@ import torch
 from torch import Tensor
 from torch.nn import Module, Parameter, Embedding
 from torch.nn.functional import linear
+from torch.utils.checkpoint import checkpoint
 from scipy.linalg import logm
 
 from .utils import pad_sequence
@@ -86,6 +87,7 @@ class TokenEmbedding(Module):
         self.scope_dropout = scope_dropout
         self.path_encoder = BinaryPathEncoder(dim=dim)
         self.embeddings = Embedding(num_embeddings=11, embedding_dim=dim)
+        self.gradient_checkpointing = True
         """
         Embedding map:
             0 [SOS]
@@ -120,7 +122,10 @@ class TokenEmbedding(Module):
 
         unique_paths, inverse = node_positions.unique(return_inverse=True)
         db_paths = torch.bucketize(token_values[db_mask], unique_paths)
-        positional_encodings = self.path_encoder.forward(unique_paths)
+        if self.gradient_checkpointing and self.training and torch.is_grad_enabled():
+            positional_encodings = checkpoint(self.path_encoder, unique_paths, use_reentrant=False)
+        else:
+            positional_encodings = self.path_encoder.forward(unique_paths)
         db_encodings = positional_encodings[inverse[db_mask]].mT @ positional_encodings[db_paths]
 
         content_embeddings = torch.zeros(
@@ -130,6 +135,6 @@ class TokenEmbedding(Module):
         content_embeddings[sos_mask] = self.embeddings.weight[0]
         content_embeddings[bop_mask] = self.embeddings.forward(token_values[bop_mask] + 1)
         content_embeddings[nop_mask] = self.embeddings.forward(token_values[nop_mask] + 5)
-        content_embeddings[db_mask] = self.embeddings.weight[8] @ db_encodings
+        content_embeddings[db_mask] = db_encodings @ self.embeddings.weight[8]
         content_embeddings[oos_mask] = self.embeddings.weight[10]
         return content_embeddings, positional_encodings[inverse, :]

--- a/src/quill/nn/embedding.py
+++ b/src/quill/nn/embedding.py
@@ -15,9 +15,9 @@ class BinaryPathEncoder(Module):
         super().__init__()
         self.dim: int = dim
         self._primitives = Parameter(
-            rope_like_init(dim // 2).unsqueeze(0).repeat(2, 1, 1),
+            rope_like_init(self.dim // 2).unsqueeze(0).repeat(2, 1, 1),
             requires_grad=True)
-        self.identity: Parameter = Parameter(torch.eye(dim).unsqueeze(0))
+        self.identity: Parameter = Parameter(torch.eye(dim).unsqueeze(0), requires_grad=False)
         self._pos_to_path: dict[int, list[bool]] = {}
 
     @property
@@ -135,6 +135,6 @@ class TokenEmbedding(Module):
         content_embeddings[sos_mask] = self.embeddings.weight[0]
         content_embeddings[bop_mask] = self.embeddings.forward(token_values[bop_mask] + 1)
         content_embeddings[nop_mask] = self.embeddings.forward(token_values[nop_mask] + 5)
-        content_embeddings[db_mask] = db_encodings @ self.embeddings.weight[8]
+        content_embeddings[db_mask] = self.embeddings.weight[8] @ db_encodings
         content_embeddings[oos_mask] = self.embeddings.weight[10]
         return content_embeddings, positional_encodings[inverse, :]

--- a/src/quill/nn/embedding.py
+++ b/src/quill/nn/embedding.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 from torch.nn import Module, Parameter, Embedding
-from torch.nn.functional import linear
 from torch.utils.checkpoint import checkpoint
 from scipy.linalg import logm
 
@@ -44,8 +43,8 @@ class BinaryPathEncoder(Module):
         right_mask = path_words == 1
 
         for step in range(path_words.size(1)):
-            maps[left_mask[:, step]] = linear(maps[left_mask[:, step]], primitives[0])
-            maps[right_mask[:, step]] = linear(maps[right_mask[:, step]], primitives[1])
+            maps[left_mask[:, step]] = maps[left_mask[:, step]] @ primitives[0]
+            maps[right_mask[:, step]] = maps[right_mask[:, step]] @ primitives[1]
         return maps
 
     def forward(self, unique: Tensor) -> Tensor:
@@ -54,7 +53,7 @@ class BinaryPathEncoder(Module):
     def pos_to_path(self, idx: int) -> list[int]:
         if idx in self._pos_to_path:
             return self._pos_to_path[idx]
-        self._pos_to_path[idx] = [] if idx == 1 else [idx % 2] + self.pos_to_path(idx // 2)
+        self._pos_to_path[idx] = [] if idx == 1 else self.pos_to_path(idx // 2) + [idx % 2]
         return self._pos_to_path[idx]
 
 

--- a/src/quill/nn/encoders.py
+++ b/src/quill/nn/encoders.py
@@ -1,6 +1,7 @@
 import torch
 from torch.nn import Module, ModuleList, Linear
 from torch import Tensor
+from torch.utils.checkpoint import checkpoint
 
 from .batching import BatchedASTs
 
@@ -76,6 +77,7 @@ class TermEncoder(Module):
                          head_dim=head_dim,
                          dropout_rate=dropout_rate)
             for _ in range(num_layers)])
+        self.gradient_checkpointing = True
 
     def forward(self,
                 dense_features: Tensor,
@@ -86,7 +88,11 @@ class TermEncoder(Module):
                 rotator: Tensor) -> Tensor:
         dense_features[reference_mask] = reference_storage[reference_ids]
 
+        ckpt = self.gradient_checkpointing and self.training and torch.is_grad_enabled()
         layer: EncoderLayer
         for layer in self.encoder:
-            dense_features = layer.forward(dense_features, padding_mask, rotator)
+            if ckpt:
+                dense_features = checkpoint(layer, dense_features, padding_mask, rotator, use_reentrant=False)
+            else:
+                dense_features = layer.forward(dense_features, padding_mask, rotator)
         return dense_features[:, 0]

--- a/src/quill/nn/model.py
+++ b/src/quill/nn/model.py
@@ -43,7 +43,7 @@ class Model(Module):
         source_index, target_index = edge_index
         sources = scope_reprs[source_index]
         targets = hole_reprs[target_index]
-        return self.lemma_predictor(self.norm(sources * targets)).squeeze(-1)
+        return self.lemma_predictor(self.norm(sources) * self.norm(targets)).squeeze(-1)
 
     def get_predictions(self, batch: Batch) -> Tensor:
         scope_reprs, hole_reprs = self.encode(batch)

--- a/src/quill/nn/training.py
+++ b/src/quill/nn/training.py
@@ -54,6 +54,29 @@ class Trainer(Model):
                           ap=ap,
                           rp=rp)
 
+    def save_checkpoint(self,
+                        path: str,
+                        optimizer: Optimizer,
+                        scheduler: LRScheduler,
+                        epoch: int,
+                        best_ap: float) -> None:
+        torch.save({'model': self.state_dict(),
+                    'optimizer': optimizer.state_dict(),
+                    'scheduler': scheduler.state_dict(),
+                    'epoch': epoch,
+                    'best_ap': best_ap}, path)
+
+    def load_checkpoint(self,
+                        path: str,
+                        optimizer: Optimizer,
+                        scheduler: LRScheduler,
+                        map_location: str) -> tuple[int, float]:
+        checkpoint = torch.load(path, map_location=map_location, weights_only=False)
+        self.load_state_dict(checkpoint['model'])
+        optimizer.load_state_dict(checkpoint['optimizer'])
+        scheduler.load_state_dict(checkpoint['scheduler'])
+        return checkpoint['epoch'] + 1, checkpoint['best_ap']
+
     def train_epoch(self,
                     epoch: Iterator[Batch],
                     optimizer: Optimizer,


### PR DESCRIPTION
Resolves a long-standing bug that would disallow matching the reported numbers.

## Bug Fixes
* Fixes a major regression with data filtering that would drop ~25% of useful training data.
* Inverts path indices to keep them in alignment with tree PE math.
* Fixes tokenization ignoring the  second in-scope definition instead of out-of-scope definitions. (_note_: tokenized.p has not yet been updated).

## Network
* RMS Norm applied per element rather than per-pair during premise-scoring.

## QoL
* Allows gradient checkpoint for reduced VRAM during training.
* Allows breaking/resuming training.
* Freshly trained model uploaded.

---

Aligning quill to the most recent version of agda2train and pinning results against it is in my to-do list. Contributions welcome.